### PR TITLE
Allow users to run in thermal noise only mode

### DIFF
--- a/mk_array_file.py
+++ b/mk_array_file.py
@@ -26,10 +26,10 @@ def beamgridder(xcen,ycen,size):
     xcen += cen
     ycen = -1*ycen + cen
     beam = n.zeros((size,size))
-    if round(ycen) > size - 1 or round(xcen) > size - 1 or ycen < 0. or xcen <0.: 
+    if n.round(ycen) > size - 1 or n.round(xcen) > size - 1 or ycen < 0. or xcen <0.: 
         return beam
     else:
-        beam[round(ycen),round(xcen)] = 1. #single pixel gridder
+        beam[int(n.round(ycen)),int(n.round(xcen))] = 1. #single pixel gridder
         return beam
 
 #==============================READ ARRAY PARAMETERS=========================
@@ -94,7 +94,7 @@ if opts.bl_max:
     print 'The longest baseline being included is %.2f m' % (bl_len_max*(a.const.c/(ref_fq*1e11)))
 
 #grid each baseline type into uv plane
-dim = n.round(bl_len_max/dish_size_in_lambda)*2 + 1 # round to nearest odd
+dim = int(n.round(bl_len_max/dish_size_in_lambda)*2 + 1) # round to nearest odd
 uvsum,quadsum = n.zeros((dim,dim)), n.zeros((dim,dim)) #quadsum adds all non-instantaneously-redundant baselines incoherently
 for cnt, uvbin in enumerate(uvbins):
     print 'working on %i of %i uvbins' % (cnt+1, len(uvbins))


### PR DESCRIPTION
By passing `--eor None`, one can run without any eor model, producing thermal noise only errors. Among other things, this allows one to go up to high k, beyond the limits of the power spectrum interpolator. In this case, both errs and T_errs are identical.

I also fixed a number of numpy issues by explicitly casting results of `round` to ints.

(Also, I fixed the tabbing in one section. Who tabs with 3 spaces?)